### PR TITLE
Set RequiresMACAddress to true in Cap. Response

### DIFF
--- a/driver/ipam_driver.go
+++ b/driver/ipam_driver.go
@@ -32,7 +32,7 @@ func NewIpamDriver(client *datastoreClient.Client) ipam.Ipam {
 }
 
 func (i IpamDriver) GetCapabilities() (*ipam.CapabilitiesResponse, error) {
-	resp := ipam.CapabilitiesResponse{}
+	resp := ipam.CapabilitiesResponse{RequiresMACAddress: true}
 	logutils.JSONMessage("GetCapabilities response", resp)
 	return &resp, nil
 }


### PR DESCRIPTION
Allow docker to manage container mac address. Associated with issue:  https://github.com/projectcalico/calicoctl/issues/1817

Description:
Docker 18.03
Calico node v2.6.8/v2.6.9

libnetwork: GET /IpamDriver.GetCapabilities
{"RequiresMACAddress":false}
instructs docker do not change MAC address inside container.

So at container inspect it's empty:
"MacAddress": ""

I can see calico netplugin response with MAC provided, but seems that Docker ignores MacAddress field:
libnetwork-plugin[32378]: time="2018-04-26T13:51:40Z" level=info msg="CreateEndpoint response" JSON="{"Interface":{"Address":"","AddressIPv6":"","MacAddress":"EE:EE:EE:EE:EE:EE"}}"``